### PR TITLE
fix: 修正插件模板中的大小写错误与错误拼写

### DIFF
--- a/PluginTemplate/MyTemplate.vstemplate
+++ b/PluginTemplate/MyTemplate.vstemplate
@@ -1,13 +1,13 @@
 <VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Project">
 	<TemplateData>
-		<Name>ClassIsland Hello world 插件</Name>
-		<Description>一个能在启动时显示 Hello world 弹窗的 ClassIsland 插件模板。</Description>
+		<Name>ClassIsland Hello World 插件</Name>
+		<Description>一个能在启动时显示 Hello World 弹窗的 ClassIsland 插件模板。</Description>
 		<ProjectType>CSharp</ProjectType>
 		<LanguageTag>csharp</LanguageTag>
 		<PlatformTag>windows</PlatformTag>
 		<ProjectTypeTag>desktop</ProjectTypeTag>
-		<ProjectTypeTag>classisland</ProjectTypeTag>
-		<ProjectTypeTag>plugin</ProjectTypeTag>
+		<ProjectTypeTag>ClassIsland</ProjectTypeTag>
+		<ProjectTypeTag>Plugin</ProjectTypeTag>
 		<ProjectSubType>
 
 		</ProjectSubType>

--- a/PluginTemplate/Plugin.cs
+++ b/PluginTemplate/Plugin.cs
@@ -12,6 +12,6 @@ public class Plugin : PluginBase
 {
     public override void Initialize(HostBuilderContext context, IServiceCollection services)
     {
-        CommonDialog.ShowInfo("Hello world!");
+        CommonDialog.ShowInfo("Hello World!");
     }
 }

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ ClassIsland 插件功能目前仍在不断更新中，请记得更新模板。
 2. 将下载的压缩包复制到`%USERPROFILE%\Documents\Visual Studio 2022\Templates\ProjectTemplates`（以 VS 2022 为例，以你电脑上的具体目录为准）
 3. 打开 Visual Studio
 4. 在【启动窗口】点击【创建新项目】，搜索“ClassIsland”
-5. 选择【ClassIslad Hello World 插件】模板创建项目
+5. 选择【ClassIsland Hello World 插件】模板创建项目
 6. 大功告成🎉，开始你的 ClassIsland 插件开发之旅吧！
 
 接下来你可以继续阅读[开发文档](https://docs.classisland.tech/dev/)，了解插件开发的更多细节。

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ ClassIsland 插件功能目前仍在不断更新中，请记得更新模板。
 1. 前往 [Releases](https://github.com/ClassIsland/PluginTemplate/releases/latest) 中下载插件模板（PluginTemplate.zip）
 2. 将下载的压缩包复制到`%USERPROFILE%\Documents\Visual Studio 2022\Templates\ProjectTemplates`（以 VS 2022 为例，以你电脑上的具体目录为准）
 3. 打开 Visual Studio
-4. 在【启动窗口】点击【创建新项目】，搜索“classisland”
-5. 选择【ClassIslad Hello world 插件】模板创建项目
+4. 在【启动窗口】点击【创建新项目】，搜索“ClassIsland”
+5. 选择【ClassIslad Hello World 插件】模板创建项目
 6. 大功告成🎉，开始你的 ClassIsland 插件开发之旅吧！
 
 接下来你可以继续阅读[开发文档](https://docs.classisland.tech/dev/)，了解插件开发的更多细节。


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/f0057990-9262-406c-a0dc-4fd9af6938c0)
![image](https://github.com/user-attachments/assets/49a4b5f0-c3e4-4868-8509-0a98e9561310)


该 PR 修正了模板关键词大小写错误与 ClassIsland 错误拼写的问题